### PR TITLE
Don't try to install static plugins

### DIFF
--- a/ubuntu/debian/gazebo-plugin-base.install
+++ b/ubuntu/debian/gazebo-plugin-base.install
@@ -1,2 +1,1 @@
 usr/lib/*/gazebo-*/plugins/*.so
-usr/lib/*/gazebo-*/plugins/*.a


### PR DESCRIPTION
The 9.13.2 builds failed:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gazebo9-debbuilder&build=550)](https://build.osrfoundation.org/job/gazebo9-debbuilder/550/) https://build.osrfoundation.org/job/gazebo9-debbuilder/550/

~~~
dh_install: Cannot find (any matches for) "usr/lib/*/gazebo-*/plugins/*.a" (tried in ., debian/tmp)

dh_install: gazebo9-plugin-base missing files: usr/lib/*/gazebo-*/plugins/*.a
~~~

With this branch:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gazebo9-debbuilder&build=567)](https://build.osrfoundation.org/job/gazebo9-debbuilder/567/) https://build.osrfoundation.org/job/gazebo9-debbuilder/567/