### PR TITLE
Include proviler_vis files in gazebo-common package

### DIFF
--- a/ubuntu/debian/gazebo-common.install
+++ b/ubuntu/debian/gazebo-common.install
@@ -1,3 +1,4 @@
 usr/share/gazebo-*/media/*
 usr/share/gazebo-*/worlds/*
 usr/share/gazebo-*/models/*
+usr/share/gazebo-*/profiler_vis/*


### PR DESCRIPTION
New gazebo 9.15.0 build misses some files:

https://build.osrfoundation.org/job/gazebo9-debbuilder/620/parsed_console/

```
dh_missing: warning: usr/share/gazebo-9/profiler_vis/index.html exists in debian/tmp but is not installed to anywhere
dh_missing: warning: usr/share/gazebo-9/profiler_vis/Code/PixelTimeRange.js exists in debian/tmp but is not installed to anywhere
dh_missing: warning: usr/share/gazebo-9/profiler_vis/Code/SampleWindow.js exists in debian/tmp but is not installed to anywhere
dh_missing: warning: usr/share/gazebo-9/profiler_vis/Code/TimelineRow.js exists in debian/tmp but is not installed to anywhere
dh_missing: warning: usr/share/gazebo-9/profiler_vis/Code/TitleWindow.js exists in debian/tmp but is not installed to anywhere
dh_missing: warning: usr/share/gazebo-9/profiler_vis/Code/TimelineWindow.js exists in debian/tmp but is not installed to anywhere
dh_missing: warning: usr/share/gazebo-9/profiler_vis/Code/DataViewReader.js exists in debian/tmp but is not installed to anywhere
dh_missing: warning: usr/share/gazebo-9/profiler_vis/Code/WebSocketConnection.js exists in debian/tmp but is not installed to anywhere
dh_missing: warning: usr/share/gazebo-9/profiler_vis/Code/Remotery.js exists in debian/tmp but is not installed to anywhere
dh_missing: warning: usr/share/gazebo-9/profiler_vis/Code/ThreadFrame.js exists in debian/tmp but is not installed to anywhere
dh_missing: warning: usr/share/gazebo-9/profiler_vis/Code/Console.js exists in debian/tmp but is not installed to anywhere
dh_missing: warning: usr/share/gazebo-9/profiler_vis/Styles/Remotery.css exists in debian/tmp but is not installed to anywhere
dh_missing: warning: usr/share/gazebo-9/profiler_vis/extern/BrowserLib/WindowManager/Code/EditBox.js exists in debian/tmp but is not installed to anywhere
...
```
